### PR TITLE
Make `pkgcheck scan` happy for `glimmer`

### DIFF
--- a/x11-misc/glimmer/glimmer-0.0.4.ebuild
+++ b/x11-misc/glimmer/glimmer-0.0.4.ebuild
@@ -170,7 +170,7 @@ LICENSE="
 	MIT
 	BSD
 	Unicode-DFS-2016
-	|| ( Apache-2.0 BSL-1.0 )
+	|| ( Apache-2.0 Boost-1.0 )
 "
 SLOT="0"
 KEYWORDS="~amd64"

--- a/x11-misc/glimmer/glimmer-0.0.4.ebuild
+++ b/x11-misc/glimmer/glimmer-0.0.4.ebuild
@@ -175,10 +175,6 @@ LICENSE="
 SLOT="0"
 KEYWORDS="~amd64"
 
-DEPEND=""
-RDEPEND="${DEPEND}"
-BDEPEND=""
-
 PATCHES=(
 	"${FILESDIR}/${P}-dependencies.patch"
 )

--- a/x11-misc/glimmer/metadata.xml
+++ b/x11-misc/glimmer/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>tokusan441@gmail.com</email>
+    <name>Hiroki Tokunaga</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">moustacheful/glimmer</remote-id>
+  </upstream>
+</pkgmetadata>


### PR DESCRIPTION
Except for `SizeViolation` which is difficult to resolve.
